### PR TITLE
Add CI workflow for building and releasing multi-architecture binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           cp build/Build/Products/Release/ocr ocr
           chmod +x ocr
-          lipo -info ocr
+          file ocr
           tar czf macOCR-${{ matrix.arch }}.tar.gz ocr
 
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
 
     steps:
       - uses: actions/checkout@v4
@@ -17,11 +20,13 @@ jobs:
       - name: Install CocoaPods
         run: pod install
 
-      - name: Build
+      - name: Build (${{ matrix.arch }})
         run: |
           xcodebuild -workspace ocr.xcworkspace \
             -scheme ocr \
             -configuration Release \
+            ARCHS="${{ matrix.arch }}" \
+            ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
@@ -31,16 +36,29 @@ jobs:
           cp "$(xcodebuild -workspace ocr.xcworkspace -scheme ocr -configuration Release -showBuildSettings \
             | grep -m1 'BUILT_PRODUCTS_DIR' | awk '{print $3}')/ocr" ocr
           chmod +x ocr
-          tar czf macOCR.tar.gz ocr
+          lipo -info ocr
+          tar czf macOCR-${{ matrix.arch }}.tar.gz ocr
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: macOCR
-          path: macOCR.tar.gz
+          name: macOCR-${{ matrix.arch }}
+          path: macOCR-${{ matrix.arch }}.tar.gz
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
 
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: macOCR.tar.gz
+          files: |
+            macOCR-x86_64.tar.gz
+            macOCR-arm64.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install CocoaPods
+        run: pod install
+
+      - name: Build
+        run: |
+          xcodebuild -workspace ocr.xcworkspace \
+            -scheme ocr \
+            -configuration Release \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Prepare artifact
+        run: |
+          cp "$(xcodebuild -workspace ocr.xcworkspace -scheme ocr -configuration Release -showBuildSettings \
+            | grep -m1 'BUILT_PRODUCTS_DIR' | awk '{print $3}')/ocr" ocr
+          chmod +x ocr
+          tar czf macOCR.tar.gz ocr
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macOCR
+          path: macOCR.tar.gz
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: macOCR.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           xcodebuild -workspace ocr.xcworkspace \
             -scheme ocr \
             -configuration Release \
+            -derivedDataPath build \
             ARCHS="${{ matrix.arch }}" \
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_IDENTITY="-" \
@@ -33,8 +34,7 @@ jobs:
 
       - name: Prepare artifact
         run: |
-          cp "$(xcodebuild -workspace ocr.xcworkspace -scheme ocr -configuration Release -showBuildSettings \
-            | grep -m1 'BUILT_PRODUCTS_DIR' | awk '{print $3}')/ocr" ocr
+          cp build/Build/Products/Release/ocr ocr
           chmod +x ocr
           lipo -info ocr
           tar czf macOCR-${{ matrix.arch }}.tar.gz ocr


### PR DESCRIPTION
@schappim 
The execution result is as follows:
https://github.com/nick322/macOCR/actions/runs/23878516173

